### PR TITLE
Fix subprocess usage, improve WSGI config

### DIFF
--- a/EXAMPLE_get_scbulletin.conf
+++ b/EXAMPLE_get_scbulletin.conf
@@ -4,6 +4,7 @@ Listen 5033
     ServerName 192.168.137.9
     SetEnv HOME /home/seiscomp/
     WSGIDaemonProcess get_scbulletin user=seiscomp group=seiscomp
+    WSGIProcessGroup get_scbulletin
     WSGIScriptAlias /get_scbulletin /home/seiscomp/proyectos_codigo/get_scbulletin/get_scbulletin.wsgi
 
     <Directory /home/seiscomp/proyectos_codigo/get_scbulletin/>

--- a/EXAMPLE_get_scbulletin.wsgi
+++ b/EXAMPLE_get_scbulletin.wsgi
@@ -4,8 +4,8 @@ os.environ['FLASK_CONFIG'] = 'production'
 os.environ['SEISCOMP_ROOT'] = "/home/seiscomp/seiscomp/"
 os.environ['HOME'] = "/home/seiscomp/"
 
-os.environ['PATH'] = f"{os.environ['PATH']}:/home/seiscomp/seiscomp/bin"
-os.environ['PYTHONPATH']=f"{os.environ['PATH']}:/home/seiscomp/seiscomp/lib/python:/home/seiscomp/.local/lib/python3.8/"
+os.environ['PATH'] += ":/home/seiscomp/seiscomp/bin"
+os.environ['PYTHONPATH'] = "/home/seiscomp/seiscomp/lib/python:/home/seiscomp/.local/lib/python3.8/"
 
 os.environ['LD_LIBRARY_PATH']= "/home/seiscomp/seiscomp/lib/"
 sys.path.insert(0,'/home/seiscomp/seiscomp/lib/python')

--- a/scbulletin_service/main/views.py
+++ b/scbulletin_service/main/views.py
@@ -3,8 +3,8 @@ Created on Mar 8, 2023
 @author: wacero
 '''
 
-import subprocess 
-from flask import Flask, request, Response, current_app, send_from_directory
+import subprocess
+from flask import Flask, request, Response, current_app, send_from_directory, abort
 from werkzeug.security import generate_password_hash, check_password_hash
 from . import main
 
@@ -34,21 +34,39 @@ def call_get_bulletin():
         user = str(request.args.get('user'))
         print("Data received %s %s " %(event_id, user))
         if user=='gv':
-            
-            try:
-                scbulletin_result = subprocess.call([f'''seiscomp-python /opt/varios/scbulletin_gv.py -d mysql://{db_user}:{db_password}@{db_host}/{db_name} -x -e -p -3 -E {event_id} > /tmp/{event_id}.txt''' ], shell=True )
 
-                print(scbulletin_result) 
+            try:
+                with open(f"/tmp/{event_id}.txt", "w") as out:
+                    subprocess.run(
+                        [
+                            "seiscomp-python",
+                            "/opt/varios/scbulletin_gv.py",
+                            "-d",
+                            f"mysql://{db_user}:{db_password}@{db_host}/{db_name}",
+                            "-x", "-e", "-p", "-3", "-E", event_id
+                        ],
+                        check=True,
+                        stdout=out
+                    )
             except Exception as e:
-                print("Error in scbulletin_gv: %s %s" %(scbulletin_result,e))
+                print(f"Error in scbulletin_gv: {e}")
 
         elif user=='ms':
             try:
-                scbulletin_result = subprocess.call([f'''seiscomp-python /opt/varios/scbulletin_ms.py -d mysql://{db_user}:{db_password}@{db_host}/{db_name} -x -e -p -3 -E {event_id} > /tmp/{event_id}.txt''' ], shell=True )
-
-                print(scbulletin_result) 
+                with open(f"/tmp/{event_id}.txt", "w") as out:
+                    subprocess.run(
+                        [
+                            "seiscomp-python",
+                            "/opt/varios/scbulletin_ms.py",
+                            "-d",
+                            f"mysql://{db_user}:{db_password}@{db_host}/{db_name}",
+                            "-x", "-e", "-p", "-3", "-E", event_id
+                        ],
+                        check=True,
+                        stdout=out
+                    )
             except Exception as e:
-                print("Error in scbulletin_ms: %s %s" %(scbulletin_result,e))
+                print(f"Error in scbulletin_ms: {e}")
         
         try:
             return send_from_directory('/tmp/','%s.txt'%event_id,as_attachment=True)


### PR DESCRIPTION
## Summary
- add missing abort import
- run external scripts with subprocess.run instead of shell=True
- specify WSGI process group in example Apache config
- clean up PYTHONPATH handling in example WSGI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68547fbe26d48327a8ef47c788088c0a